### PR TITLE
Fix prisma ssl error

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -6,6 +6,7 @@
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
### Why
容器内npm run start 报错：
<img width="2160" alt="Screenshot 2024-12-18 at 13 37 24" src="https://github.com/user-attachments/assets/eed3c9eb-055b-4fa8-bd56-0faef7b41a68" />

相同的问题在部署后端服务时也遇到过
Refer - https://github.com/onrunning/china-omni-channel-product-service/blob/main/prisma/schema.prisma#L6

### Review Instructions
Merge这个改动后错误消失，已验证。